### PR TITLE
Deploy to heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM verdaccio/verdaccio:3.12.3
+
+USER root
+
+ENV NODE_ENV=production
+
+RUN yarn && yarn add verdaccio-github-oauth-ui
+
+COPY ./config.yaml /verdaccio/conf
+
+USER verdaccio

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # verdaccio-heroku-docker
+
+A containerized verdaccio private npm registry configured with github oauth.
+
+## Deployment
+
+You can deploy to heroku with one click
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+Once the app has been deployed, you will need to setup a github oauth app and add the necessary
+oauth credentials as heroku config vars.
+
+[Follow these instructions](https://github.com/n4bb12/verdaccio-github-oauth-ui#github-config) when
+creating the oauth app.
+
+- Add the following config vars to the heroku app. Either do this from the [heroku dashboard](https://devcenter.heroku.com/articles/config-vars#using-the-heroku-dashboard)
+or with the [cli](https://devcenter.heroku.com/articles/config-vars#using-the-heroku-cli).
+
+```
+GITHUB_OAUTH_ORG
+GITHUB_OAUTH_CLIENT_ID
+GITHUB_OAUTH_CLIENT_SECRET
+```
+
+You should now be able to visit the heroku app and login with your github account by clicking the
+login button and going through the oauth flow.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "verdaccio-github-oauth",
+  "description": "A private npm registry authenticated with github oauth",
+  "repository": "https://github.com/autotelic/verdaccio-heroku-docker",
+  "keywords": ["verdaccio", "docker", "npm"],
+  "stack": "container"
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,20 @@
+storage: ./storage
+auth:
+  github-oauth-ui:
+    org: GITHUB_OAUTH_ORG
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@*/*':
+    access: $authenticated
+    publish: $authenticated
+    proxy: npmjs
+  '**':
+    proxy: npmjs
+logs:
+  - {type: stdout, format: pretty, level: http}
+middlewares:
+  github-oauth-ui:
+    client-id: GITHUB_OAUTH_CLIENT_ID
+    client-secret: GITHUB_OAUTH_CLIENT_SECRET

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
# Summary

Configures a private verdaccio npm registry with github oauth that can be easily deployed to heroku.

# Test Plan

Follow the steps outlined in the `README.md` to deploy the registry and login.