### PR TITLE
Packages authentication configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,8 @@ packages:
     proxy: npmjs
   '**':
     proxy: npmjs
+    access: $authenticated
+    publish: $authenticated
 logs:
   - {type: stdout, format: pretty, level: http}
 middlewares:


### PR DESCRIPTION
# Summary

Configure the registry to allow authenticated users to publish non-scoped packages.

